### PR TITLE
Support Kubernetes v1.25

### DIFF
--- a/mesh/Chart.yaml
+++ b/mesh/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: traefik-mesh
-version: 4.0.4
+version: 4.0.5
 appVersion: v1.4.8
 description: Traefik Mesh - Simpler Service Mesh
 type: application

--- a/mesh/Chart.yaml
+++ b/mesh/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: traefik-mesh
-version: 4.0.5
+version: 4.1.0
 appVersion: v1.4.8
 description: Traefik Mesh - Simpler Service Mesh
 type: application
@@ -28,8 +28,8 @@ maintainers:
 icon: https://raw.githubusercontent.com/traefik/mesh/master/docs/content/assets/img/traefik-mesh.png
 dependencies:
   - name: tracing
-    version: 0.0.3
+    version: 0.1.0
     condition: tracing.deploy
   - name: metrics
-    version: 0.1.0
+    version: 0.2.0
     condition: metrics.deploy

--- a/mesh/README.md
+++ b/mesh/README.md
@@ -7,7 +7,7 @@ Moreover, Traefik Mesh is opt-in by default, which means that your existing serv
 
 ## Prerequisites
 
-- Kubernetes 1.16+
+- Kubernetes 1.21+
 - CoreDNS/KubeDNS installed as [Cluster DNS Provider](https://kubernetes.io/docs/tasks/administer-cluster/dns-custom-nameservers/) (versions 1.3+ supported)
 - [Helm v3](https://helm.sh/docs/intro/install/)
 

--- a/mesh/charts/metrics/Chart.yaml
+++ b/mesh/charts/metrics/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 description: A metrics Helm chart for Kubernetes
 name: metrics
-version: 0.1.0
+version: 0.2.0
 appVersion: 0.0.1
 tillerVersion: ">=2.7.2"

--- a/mesh/charts/metrics/templates/grafana-pdb.yaml
+++ b/mesh/charts/metrics/templates/grafana-pdb.yaml
@@ -1,9 +1,5 @@
 ---
-{{- if .Capabilities.APIVersions.Has "policy/v1" }}
 apiVersion: policy/v1
-{{- else }}
-apiVersion: policy/v1beta1
-{{- end }}
 kind: PodDisruptionBudget
 metadata:
   name: grafana

--- a/mesh/charts/metrics/templates/grafana-pdb.yaml
+++ b/mesh/charts/metrics/templates/grafana-pdb.yaml
@@ -1,5 +1,9 @@
 ---
+{{- if .Capabilities.APIVersions.Has "policy/v1" }}
+apiVersion: policy/v1
+{{- else }}
 apiVersion: policy/v1beta1
+{{- end }}
 kind: PodDisruptionBudget
 metadata:
   name: grafana

--- a/mesh/charts/metrics/templates/prometheus-pdb.yaml
+++ b/mesh/charts/metrics/templates/prometheus-pdb.yaml
@@ -1,9 +1,5 @@
 ---
-{{- if .Capabilities.APIVersions.Has "policy/v1" }}
 apiVersion: policy/v1
-{{- else }}
-apiVersion: policy/v1beta1
-{{- end }}
 kind: PodDisruptionBudget
 metadata:
   name: prometheus

--- a/mesh/charts/metrics/templates/prometheus-pdb.yaml
+++ b/mesh/charts/metrics/templates/prometheus-pdb.yaml
@@ -1,5 +1,9 @@
 ---
+{{- if .Capabilities.APIVersions.Has "policy/v1" }}
+apiVersion: policy/v1
+{{- else }}
 apiVersion: policy/v1beta1
+{{- end }}
 kind: PodDisruptionBudget
 metadata:
   name: prometheus

--- a/mesh/charts/tracing/Chart.yaml
+++ b/mesh/charts/tracing/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 description: A Jaeger tracing Helm chart for Kubernetes
 name: tracing
-version: 0.0.3
+version: 0.1.0
 appVersion: 0.0.1
 tillerVersion: ">=2.7.2"

--- a/mesh/charts/tracing/templates/jaeger-pdb.yaml
+++ b/mesh/charts/tracing/templates/jaeger-pdb.yaml
@@ -1,5 +1,9 @@
 ---
+{{- if .Capabilities.APIVersions.Has "policy/v1" }}
+apiVersion: policy/v1
+{{- else }}
 apiVersion: policy/v1beta1
+{{- end }}
 kind: PodDisruptionBudget
 metadata:
   name: jaeger

--- a/mesh/charts/tracing/templates/jaeger-pdb.yaml
+++ b/mesh/charts/tracing/templates/jaeger-pdb.yaml
@@ -1,9 +1,5 @@
 ---
-{{- if .Capabilities.APIVersions.Has "policy/v1" }}
 apiVersion: policy/v1
-{{- else }}
-apiVersion: policy/v1beta1
-{{- end }}
 kind: PodDisruptionBudget
 metadata:
   name: jaeger

--- a/mesh/templates/controller/controller-pdb.yaml
+++ b/mesh/templates/controller/controller-pdb.yaml
@@ -1,9 +1,5 @@
 ---
-{{- if .Capabilities.APIVersions.Has "policy/v1" }}
 apiVersion: policy/v1
-{{- else }}
-apiVersion: policy/v1beta1
-{{- end }}
 kind: PodDisruptionBudget
 metadata:
   name: traefik-mesh-controller

--- a/mesh/templates/controller/controller-pdb.yaml
+++ b/mesh/templates/controller/controller-pdb.yaml
@@ -1,5 +1,9 @@
 ---
+{{- if .Capabilities.APIVersions.Has "policy/v1" }}
+apiVersion: policy/v1
+{{- else }}
 apiVersion: policy/v1beta1
+{{- end }}
 kind: PodDisruptionBudget
 metadata:
   name: traefik-mesh-controller


### PR DESCRIPTION
If trying to run the chart on k9s version 1.25, it will cause the release not to deploy with the following error: 
```
❯ helm install traefik-mesh traefik-mesh/traefik-mesh
Error: INSTALLATION FAILED: unable to build kubernetes objects from release manifest: [resource mapping not found for name: "grafana" namespace: "" from "": no matches for kind "PodDisruptionBudget" in version "policy/v1beta1"
ensure CRDs are installed first, resource mapping not found for name: "prometheus" namespace: "" from "": no matches for kind "PodDisruptionBudget" in version "policy/v1beta1"
ensure CRDs are installed first, resource mapping not found for name: "jaeger" namespace: "" from "": no matches for kind "PodDisruptionBudget" in version "policy/v1beta1"
ensure CRDs are installed first, resource mapping not found for name: "traefik-mesh-controller" namespace: "default" from "": no matches for kind "PodDisruptionBudget" in version "policy/v1beta1"
ensure CRDs are installed first]
```

This should use the right API version.