### PR TITLE
Bump dependencies

### DIFF
--- a/mesh/charts/metrics/values.yaml
+++ b/mesh/charts/metrics/values.yaml
@@ -1,7 +1,7 @@
 image:
-  prometheus: prom/prometheus:v2.11.1
-  grafana: grafana/grafana:6.2.5
-  configmapReload: jimmidyson/configmap-reload:v0.2.2
+  prometheus: prom/prometheus:v2.41.0
+  grafana: grafana/grafana:9.3.2
+  configmapReload: jimmidyson/configmap-reload:v0.8.0
 
 grafana:
   service:

--- a/mesh/charts/tracing/values.yaml
+++ b/mesh/charts/tracing/values.yaml
@@ -1,2 +1,2 @@
 image:
-  jaeger: jaegertracing/all-in-one:1.18
+  jaeger: jaegertracing/all-in-one:1.40


### PR DESCRIPTION
Bump

-  prometheus: v2.11.1->v2.41.0
-  grafana: 6.2.5->9.3.2
-  configmapReload: v0.2.2->v0.8.0
-  jaeger: 1.18->1.40